### PR TITLE
feature: Add ability to save the dot graph for further processing

### DIFF
--- a/smach_viewer/scripts/smach_viewer.py
+++ b/smach_viewer/scripts/smach_viewer.py
@@ -32,6 +32,7 @@
 
 import roslib; roslib.load_manifest('smach_viewer')
 import rospy
+import rospkg
 
 from smach_msgs.msg import SmachContainerStatus,SmachContainerInitialStatusCmd,SmachContainerStructure
 
@@ -43,6 +44,7 @@ import pprint
 import copy
 import StringIO
 import colorsys
+import time
 
 import wxversion
 wxversion.select("2.8")

--- a/smach_viewer/scripts/smach_viewer.py
+++ b/smach_viewer/scripts/smach_viewer.py
@@ -444,7 +444,8 @@ class SmachViewerFrame(wx.Frame):
         self._top_containers = {}
         self._update_cond = threading.Condition()
         self._needs_refresh = True
-        
+        self.dotstr = ''
+
         vbox = wx.BoxSizer(wx.VERTICAL)
 
 
@@ -513,10 +514,13 @@ class SmachViewerFrame(wx.Frame):
         toolbar.AddControl(wx.StaticText(toolbar,-1,"    "))
         toolbar.AddLabelTool(wx.ID_HELP, 'Help',
                 wx.ArtProvider.GetBitmap(wx.ART_HELP,wx.ART_OTHER,(16,16)) )
+        toolbar.AddLabelTool(wx.ID_SAVE, 'Save',
+                wx.ArtProvider.GetBitmap(wx.ART_FILE_SAVE,wx.ART_OTHER,(16,16)) )
         toolbar.Realize()
 
 
         self.Bind(wx.EVT_TOOL, self.ShowControlsDialog, id=wx.ID_HELP)
+        self.Bind(wx.EVT_TOOL, self.SaveDotGraph, id=wx.ID_SAVE)
 
         # Create dot graph widget
         self.widget = xdot.wxxdot.WxDotWindow(graph_view, -1)
@@ -843,7 +847,7 @@ class SmachViewerFrame(wx.Frame):
                         dotstr += '"__empty__" [label="Path not available.", shape="plaintext"]'
 
                     dotstr += '\n}\n'
-
+                    self.dotstr = dotstr
                     # Set the dotcode to the new dotcode, reset the flags
                     self.set_dotcode(dotstr,zoom=False)
                     self._structure_changed = False
@@ -951,6 +955,16 @@ class SmachViewerFrame(wx.Frame):
                 "Pan: Arrow Keys\nZoom: PageUp / PageDown\nZoom To Fit: F\nRefresh: R",
                 'Keyboard Controls', wx.OK)
         dial.ShowModal()
+
+    def SaveDotGraph(self,event):
+        timestr = time.strftime("%Y%m%d-%H%M%S")
+        directory = rospkg.get_ros_home()+'/dotfiles/'
+        if not os.path.exists(directory):
+                os.makedirs(directory)
+        filename = directory+timestr+'.dot'
+        print('Writing to file: %s' % filename)
+        with open(filename, 'w') as f:
+            f.write(self.dotstr)
 
     def OnExit(self, event):
         pass


### PR DESCRIPTION
Add a icon which enables the user to save the currently displayed graph as a .dot file in the currently hardcoded ros_home/dotfiles, which should normaly be $HOME/.ros/dotfiles
From there it can be converted with the dot commandline tool into png, pdf or others without the problem of quality loss.
