### PR TITLE
add ROS Orphaned Package Maintainers to maintainer tag

### DIFF
--- a/executive_smach_visualization/package.xml
+++ b/executive_smach_visualization/package.xml
@@ -6,6 +6,7 @@
     This metapackage depends on the SMACH visualization tools.
   </description>
   <maintainer email="jbo@jhu.edu">Jonathan Bohren</maintainer>
+  <maintainer email="ros-orphaned-packages@googlegroups.com">ROS Orphaned Package Maintainers</maintainer>
   <license>BSD</license>
 
   <url>http://ros.org/wiki/smach</url>

--- a/smach_viewer/package.xml
+++ b/smach_viewer/package.xml
@@ -11,6 +11,7 @@
     messages</a> to gather information from running state machines.
   </description>
   <maintainer email="jbo@jhu.edu">Jonathan Bohren</maintainer>
+  <maintainer email="ros-orphaned-packages@googlegroups.com">ROS Orphaned Package Maintainers</maintainer>
 
   <license>BSD</license>
 


### PR DESCRIPTION
@jbohren I am willing to release this repository on behalf of unmaintaned package maintaner groups, so could you give @k-okada write access? thaks in advance

we also needs access to https://github.com/jbohren/executive_smach_visualization-release too