### PR TITLE
Allow launching from a launch file, use rospy.myargv() to remove ROS remapping arguments

### DIFF
--- a/smach_viewer/scripts/smach_viewer.py
+++ b/smach_viewer/scripts/smach_viewer.py
@@ -3,10 +3,10 @@
 # Copyright (c) 2010, Willow Garage, Inc.
 # All rights reserved.
 # Copyright (c) 2013, Jonathan Bohren, The Johns Hopkins University
-#
+# 
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
-#
+# 
 #   * Redistributions of source code must retain the above copyright
 #       notice, this list of conditions and the following disclaimer.
 #   * Redistributions in binary form must reproduce the above copyright
@@ -15,7 +15,7 @@
 #   * Neither the name of the Willow Garage, Inc. nor the names of its
 #       contributors may be used to endorse or promote products derived from
 #       this software without specific prior written permission.
-#
+# 
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 # AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 # IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -28,7 +28,7 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 #
-# Author: Jonathan Bohren
+# Author: Jonathan Bohren 
 
 import rospy
 import rospkg
@@ -111,11 +111,11 @@ def hex2t(color_str):
 
 class ContainerNode():
     """
-    This class represents a given container in a running SMACH system.
+    This class represents a given container in a running SMACH system. 
 
     Its primary use is to generate dotcode for a SMACH container. It has
     methods for responding to structure and status messages from a SMACH
-    introspection server, as well as methods for updating the styles of a
+    introspection server, as well as methods for updating the styles of a 
     graph once it's been drawn.
     """
     def __init__(self, server_name, msg):
@@ -198,7 +198,7 @@ class ContainerNode():
 
     def get_dotcode(self, selected_paths, closed_paths, depth, max_depth, containers, show_all, label_wrapper, attrs={}):
         """Generate the dotcode representing this container.
-
+        
         @param selected_paths: The paths to nodes that are selected
         @closed paths: The paths that shouldn't be expanded
         @param depth: The depth to start traversing the tree
@@ -356,7 +356,7 @@ class ContainerNode():
         """Update the styles for a list of containers without regenerating the dotcode.
 
         This function is called recursively to update an entire tree.
-
+        
         @param selected_paths: A list of paths to nodes that are currently selected.
         @param depth: The depth to start traversing the tree
         @param max_depth: The depth to traverse into the tree
@@ -410,7 +410,7 @@ class ContainerNode():
                 if child_path in selected_paths:
                     child_color = hex2t('#FB000DFF')
 
-                # Generate dotcode for child containers
+                # Generate dotcode for child containers 
                 if child_path in containers:
                     subgraph_id = 'cluster_'+child_path
                     if subgraph_id in subgraph_shapes:
@@ -425,7 +425,7 @@ class ContainerNode():
                                 v = 0.85
                             child_fillcolor = [v,v,v,1.0]
 
-
+                        
                         for shape in subgraph_shapes['cluster_'+child_path]:
                             pen = shape.pen
                             if len(pen.color) > 3:
@@ -482,7 +482,7 @@ class SmachViewerFrame(wx.Frame):
         # Create viewer pane
         viewer = wx.Panel(self.content_splitter,-1)
 
-        # Create smach viewer
+        # Create smach viewer 
         nb = wx.Notebook(viewer,-1,style=wx.NB_TOP | wx.WANTS_CHARS)
         viewer_box = wx.BoxSizer()
         viewer_box.Add(nb,1,wx.EXPAND | wx.ALL, 4)
@@ -581,7 +581,7 @@ class SmachViewerFrame(wx.Frame):
 
         self.ud_txt = wx.TextCtrl(self.ud_win,-1,style=wx.TE_MULTILINE | wx.TE_READONLY)
         self.ud_gs.Add(self.ud_txt,1,wx.EXPAND | borders, border)
-
+        
         # Add initial state button
         self.is_button = wx.Button(self.ud_win,-1,"Set as Initial State")
         self.is_button.Bind(wx.EVT_BUTTON, self.on_set_initial_state)
@@ -641,7 +641,7 @@ class SmachViewerFrame(wx.Frame):
         self._server_list_thread.join()
         self._update_graph_thread.join()
         self._update_tree_thread.join()
-
+        
         event.Skip()
 
     def update_graph(self):
@@ -794,7 +794,7 @@ class SmachViewerFrame(wx.Frame):
 
             # Update the structure of this known container
             needs_redraw = self._containers[path].update_structure(msg)
-        else:
+        else: 
             rospy.logdebug("CONSTRUCTING: "+path)
 
             # Create a new container
@@ -857,7 +857,7 @@ class SmachViewerFrame(wx.Frame):
 
           1: The structure of the SMACH plans has changed, or the display
           settings have been changed. In this case, the dotcode needs to be
-          regenerated.
+          regenerated. 
 
           2: The status of the SMACH plans has changed. In this case, we only
           need to change the styles of the graph.
@@ -1001,8 +1001,8 @@ class SmachViewerFrame(wx.Frame):
 
             # This doesn't need to happen very often
             rospy.sleep(1.0)
-
-
+            
+            
             #self.server_combo.AppendItems([s for s in self._servers if s not in current_servers])
 
             # Grab the first server

--- a/smach_viewer/scripts/smach_viewer.py
+++ b/smach_viewer/scripts/smach_viewer.py
@@ -3,10 +3,10 @@
 # Copyright (c) 2010, Willow Garage, Inc.
 # All rights reserved.
 # Copyright (c) 2013, Jonathan Bohren, The Johns Hopkins University
-# 
+#
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
-# 
+#
 #   * Redistributions of source code must retain the above copyright
 #       notice, this list of conditions and the following disclaimer.
 #   * Redistributions in binary form must reproduce the above copyright
@@ -15,7 +15,7 @@
 #   * Neither the name of the Willow Garage, Inc. nor the names of its
 #       contributors may be used to endorse or promote products derived from
 #       this software without specific prior written permission.
-# 
+#
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 # AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 # IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -28,7 +28,7 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 #
-# Author: Jonathan Bohren 
+# Author: Jonathan Bohren
 
 import rospy
 import rospkg
@@ -111,11 +111,11 @@ def hex2t(color_str):
 
 class ContainerNode():
     """
-    This class represents a given container in a running SMACH system. 
+    This class represents a given container in a running SMACH system.
 
     Its primary use is to generate dotcode for a SMACH container. It has
     methods for responding to structure and status messages from a SMACH
-    introspection server, as well as methods for updating the styles of a 
+    introspection server, as well as methods for updating the styles of a
     graph once it's been drawn.
     """
     def __init__(self, server_name, msg):
@@ -198,7 +198,7 @@ class ContainerNode():
 
     def get_dotcode(self, selected_paths, closed_paths, depth, max_depth, containers, show_all, label_wrapper, attrs={}):
         """Generate the dotcode representing this container.
-        
+
         @param selected_paths: The paths to nodes that are selected
         @closed paths: The paths that shouldn't be expanded
         @param depth: The depth to start traversing the tree
@@ -356,7 +356,7 @@ class ContainerNode():
         """Update the styles for a list of containers without regenerating the dotcode.
 
         This function is called recursively to update an entire tree.
-        
+
         @param selected_paths: A list of paths to nodes that are currently selected.
         @param depth: The depth to start traversing the tree
         @param max_depth: The depth to traverse into the tree
@@ -410,7 +410,7 @@ class ContainerNode():
                 if child_path in selected_paths:
                     child_color = hex2t('#FB000DFF')
 
-                # Generate dotcode for child containers 
+                # Generate dotcode for child containers
                 if child_path in containers:
                     subgraph_id = 'cluster_'+child_path
                     if subgraph_id in subgraph_shapes:
@@ -425,7 +425,7 @@ class ContainerNode():
                                 v = 0.85
                             child_fillcolor = [v,v,v,1.0]
 
-                        
+
                         for shape in subgraph_shapes['cluster_'+child_path]:
                             pen = shape.pen
                             if len(pen.color) > 3:
@@ -482,7 +482,7 @@ class SmachViewerFrame(wx.Frame):
         # Create viewer pane
         viewer = wx.Panel(self.content_splitter,-1)
 
-        # Create smach viewer 
+        # Create smach viewer
         nb = wx.Notebook(viewer,-1,style=wx.NB_TOP | wx.WANTS_CHARS)
         viewer_box = wx.BoxSizer()
         viewer_box.Add(nb,1,wx.EXPAND | wx.ALL, 4)
@@ -581,7 +581,7 @@ class SmachViewerFrame(wx.Frame):
 
         self.ud_txt = wx.TextCtrl(self.ud_win,-1,style=wx.TE_MULTILINE | wx.TE_READONLY)
         self.ud_gs.Add(self.ud_txt,1,wx.EXPAND | borders, border)
-        
+
         # Add initial state button
         self.is_button = wx.Button(self.ud_win,-1,"Set as Initial State")
         self.is_button.Bind(wx.EVT_BUTTON, self.on_set_initial_state)
@@ -641,7 +641,7 @@ class SmachViewerFrame(wx.Frame):
         self._server_list_thread.join()
         self._update_graph_thread.join()
         self._update_tree_thread.join()
-        
+
         event.Skip()
 
     def update_graph(self):
@@ -794,7 +794,7 @@ class SmachViewerFrame(wx.Frame):
 
             # Update the structure of this known container
             needs_redraw = self._containers[path].update_structure(msg)
-        else: 
+        else:
             rospy.logdebug("CONSTRUCTING: "+path)
 
             # Create a new container
@@ -857,7 +857,7 @@ class SmachViewerFrame(wx.Frame):
 
           1: The structure of the SMACH plans has changed, or the display
           settings have been changed. In this case, the dotcode needs to be
-          regenerated. 
+          regenerated.
 
           2: The status of the SMACH plans has changed. In this case, we only
           need to change the styles of the graph.
@@ -1001,8 +1001,8 @@ class SmachViewerFrame(wx.Frame):
 
             # This doesn't need to happen very often
             rospy.sleep(1.0)
-            
-            
+
+
             #self.server_combo.AppendItems([s for s in self._servers if s not in current_servers])
 
             # Grab the first server
@@ -1055,5 +1055,5 @@ def main():
 
 if __name__ == '__main__':
     rospy.init_node('smach_viewer',anonymous=False, disable_signals=True,log_level=rospy.INFO)
-
+    sys.argv = rospy.myargv()
     main()


### PR DESCRIPTION
Required to allow launching from a launch file, otherwise get errors of the type:
```
usage: smach_viewer.py [-h] [-f]
smach_viewer.py: error: unrecognized arguments: __name:=smach_viewer
```