### PR TITLE
[FIX] 'Jump' object has no attribute 'url'

### DIFF
--- a/smach_viewer/scripts/smach_viewer.py
+++ b/smach_viewer/scripts/smach_viewer.py
@@ -710,7 +710,7 @@ class SmachViewerFrame(wx.Frame):
         """Event: Click to select a graph node to display user data and update the graph."""
 
         # Only set string status
-       try:
+        try:
             if not type(item.url) is str:
                 return
         except AttributeError:

--- a/smach_viewer/scripts/smach_viewer.py
+++ b/smach_viewer/scripts/smach_viewer.py
@@ -708,7 +708,10 @@ class SmachViewerFrame(wx.Frame):
         """Event: Click to select a graph node to display user data and update the graph."""
 
         # Only set string status
-        if not type(item.url) is str:
+       try:
+            if not type(item.url) is str:
+                return
+        except AttributeError:
             return
 
         self.statusbar.SetStatusText(item.url)


### PR DESCRIPTION
Fix for AttributeError: 'Jump' object has no attribute 'url'
To reproduce:

- roscore
- rosrun smach_viewer smach_viewer.py
- Press "+" button to increase depth and hover over/click text "Path not available"
- Error prints in terminal