### PR TITLE
use custom TextWrapper to wrap a sentence of multibyte languages into several lines

### DIFF
--- a/smach_viewer/scripts/smach_viewer.py
+++ b/smach_viewer/scripts/smach_viewer.py
@@ -1034,7 +1034,16 @@ class SmachViewerFrame(wx.Frame):
                     dotstr += '\n}\n'
                     self.dotstr = dotstr
                     # Set the dotcode to the new dotcode, reset the flags
-                    self.set_dotcode(dotstr,zoom=False)
+                    try:
+                        self.set_dotcode(dotstr, zoom=False)
+                    except UnicodeDecodeError as e:
+                        # multibyte language only accepts even number
+                        label_width = self._label_wrapper.width
+                        rospy.logerr('label width {} causes error'.format(label_width))
+                        rospy.logerr('maybe multibyte word is in your label.')
+                        rospy.logerr(e)
+                        rospy.logerr('changing width label width to {}'.format(label_width + 1))
+                        self._label_wrapper.width = label_width + 1
                     self._structure_changed = False
 
                 # Update the styles for the graph if there are any updates

--- a/smach_viewer/scripts/smach_viewer.py
+++ b/smach_viewer/scripts/smach_viewer.py
@@ -53,7 +53,9 @@ else:
 import wx
 import wx.richtext
 
+from itertools import groupby
 import textwrap
+import unicodedata
 
 ## this import system (or ros-released) xdot
 # import xdot
@@ -108,6 +110,123 @@ def hex2t(color_str):
     """Convert a hexadecimal color strng into a color tuple."""
     color_tuple = [int(color_str[i:i+2],16)/255.0    for i in range(1,len(color_str),2)]
     return color_tuple
+
+
+# these codes are copied and modified from sphinx
+# https://github.com/sphinx-doc/sphinx/commit/00fa1b2505adbaec66496ec20fa5952da976496d
+def column_width(text):
+    east_asian_widths = {
+        'W': 2,   # Wide
+        'F': 2,   # Full-width (wide)
+        'Na': 1,  # Narrow
+        'H': 1,   # Half-width (narrow)
+        'N': 1,   # Neutral (not East Asian, treated as narrow)
+        'A': 1    # Ambiguous (s/b wide in East Asian context
+    }
+    if isinstance(text, str) and sys.version_info < (3, 0):
+        return len(text)
+    combining_correction = sum([-1 for c in text
+                                if unicodedata.combining(c)])
+    try:
+        width = sum([east_asian_widths[unicodedata.east_asian_width(c)]
+                     for c in text])
+    except AttributeError:  # east_asian_width() New in version 2.4.
+        width = len(text)
+    return width + combining_correction
+
+
+class TextWrapper(textwrap.TextWrapper):
+
+    def _wrap_chunks(self, chunks):
+        """_wrap_chunks(chunks : [string]) -> [string]
+
+        Original _wrap_chunks use len() to calculate width.
+        This method respect to wide/fullwidth characters for width adjustment.
+        """
+        lines = []
+        if self.width <= 0:
+            raise ValueError("invalid width %r (must be > 0)" % self.width)
+
+        chunks.reverse()
+
+        while chunks:
+            cur_line = []
+            cur_len = 0
+
+            if lines:
+                indent = self.subsequent_indent
+            else:
+                indent = self.initial_indent
+
+            width = self.width - column_width(indent)
+
+            if self.drop_whitespace and chunks[-1].strip() == '' and lines:
+                del chunks[-1]
+
+            while chunks:
+                c_l = column_width(chunks[-1])
+
+                if cur_len + c_l <= width:
+                    cur_line.append(chunks.pop())
+                    cur_len += c_l
+
+                else:
+                    break
+
+            if chunks and column_width(chunks[-1]) > width:
+                self._handle_long_word(chunks, cur_line, cur_len, width)
+
+            if (self.drop_whitespace and cur_line
+                    and cur_line[-1].strip() == ''):
+                del cur_line[-1]
+
+            if cur_line:
+                lines.append(indent + ''.join(cur_line))
+
+        return lines
+
+    def _break_word(self, word, space_left):
+        """_break_word(word : string, space_left : int) -> (string, string)
+
+        Break line by unicode width instead of len(word).
+        """
+        total = 0
+        for i, c in enumerate(word):
+            total += column_width(c)
+            if total > space_left:
+                return word[:i-1], word[i-1:]
+        return word, ''
+
+    def _split(self, text):
+        """_split(text : string) -> [string]
+
+        Override original method that only split by 'wordsep_re'.
+        This '_split' split wide-characters into chunk by one character.
+        """
+        split = lambda t: textwrap.TextWrapper._split(self, t)
+        chunks = []
+        for chunk in split(text):
+            for w, g in groupby(chunk, column_width):
+                if w == 1:
+                    chunks.extend(split(''.join(g)))
+                else:
+                    chunks.extend(list(g))
+        return chunks
+
+    def _handle_long_word(self, reversed_chunks, cur_line, cur_len, width):
+        """_handle_long_word(chunks : [string], cur_line : [string], cur_len : int, width : int)
+
+        Override original method for using self._break_word() instead of slice.
+        """
+        space_left = max(width - cur_len, 1)
+        if self.break_long_words:
+            l, r = self._break_word(reversed_chunks[-1], space_left)
+            cur_line.append(l)
+            reversed_chunks[-1] = r
+
+        elif not cur_line:
+            cur_line.append(reversed_chunks.pop())
+
 
 class ContainerNode():
     """
@@ -525,7 +644,7 @@ class SmachViewerFrame(wx.Frame):
                 max=1337,
                 initial=40)
         self.width_spinner.Bind(wx.EVT_SPINCTRL,self.set_label_width)
-        self._label_wrapper = textwrap.TextWrapper(40,break_long_words=True)
+        self._label_wrapper = TextWrapper(40,break_long_words=True)
         toolbar.AddControl(wx.StaticText(toolbar,-1,"    Label Width: "))
         toolbar.AddControl(self.width_spinner)
 


### PR DESCRIPTION
## Current `melodic-devel` branch + Line width `40`

this PR fixes the issue when we put long node name in multibyte language such as japanese with low label width like `40`.
the error is caused by textwrap because it wraps in the middle of multibyte language and breaks the unicode encodings.
this PR changes to use textwrapper, which supports multibyte language and used in sphinx.
https://github.com/sphinx-doc/sphinx/commit/00fa1b2505adbaec66496ec20fa5952da976496d

```
Exception in thread Thread-6:
Traceback (most recent call last):
  File "/usr/lib/python2.7/threading.py", line 801, in __bootstrap_inner
    self.run()
  File "/usr/lib/python2.7/threading.py", line 754, in run
    self.__target(*self.__args, **self.__kwargs)
  File "/home/knorth55/ros/melodic/src/ros-visualization/executive_smach_visualization/smach_viewer/scripts/smach_viewer.py", line 918, in _update_graph
    self.set_dotcode(dotstr,zoom=False)
  File "/home/knorth55/ros/melodic/src/ros-visualization/executive_smach_visualization/smach_viewer/scripts/smach_viewer.py", line 936, in set_dotcode
    if self.widget.set_dotcode(dotcode, None):
  File "/home/knorth55/ros/melodic/src/ros-visualization/executive_smach_visualization/smach_viewer/src/smach_viewer/xdot/wxxdot.py", line 460, in set_dotcode
    self.set_xdotcode(xdotcode)
  File "/home/knorth55/ros/melodic/src/ros-visualization/executive_smach_visualization/smach_viewer/src/smach_viewer/xdot/wxxdot.py", line 488, in set_xdotcode
    self.graph = parser.parse()
  File "/home/knorth55/ros/melodic/src/ros-visualization/executive_smach_visualization/smach_viewer/src/smach_viewer/xdot/xdot.py", line 1304, in parse
    DotParser.parse(self)
  File "/home/knorth55/ros/melodic/src/ros-visualization/executive_smach_visualization/smach_viewer/src/smach_viewer/xdot/xdot.py", line 1096, in parse
    self.parse_graph()
  File "/home/knorth55/ros/melodic/src/ros-visualization/executive_smach_visualization/smach_viewer/src/smach_viewer/xdot/xdot.py", line 1105, in parse_graph
    self.parse_stmt()
  File "/home/knorth55/ros/melodic/src/ros-visualization/executive_smach_visualization/smach_viewer/src/smach_viewer/xdot/xdot.py", line 1138, in parse_stmt
    self.parse_subgraph()
  File "/home/knorth55/ros/melodic/src/ros-visualization/executive_smach_visualization/smach_viewer/src/smach_viewer/xdot/xdot.py", line 1119, in parse_subgraph
    self.parse_stmt()
  File "/home/knorth55/ros/melodic/src/ros-visualization/executive_smach_visualization/smach_viewer/src/smach_viewer/xdot/xdot.py", line 1154, in parse_stmt
    self.handle_node(id, attrs)
  File "/home/knorth55/ros/melodic/src/ros-visualization/executive_smach_visualization/smach_viewer/src/smach_viewer/xdot/xdot.py", line 1278, in handle_node
    shapes.extend(parser.parse())
  File "/home/knorth55/ros/melodic/src/ros-visualization/executive_smach_visualization/smach_viewer/src/smach_viewer/xdot/xdot.py", line 705, in parse
    t = s.read_text()
  File "/home/knorth55/ros/melodic/src/ros-visualization/executive_smach_visualization/smach_viewer/src/smach_viewer/xdot/xdot.py", line 609, in read_text
    res = res.decode('utf-8')
  File "/usr/lib/python2.7/encodings/utf_8.py", line 16, in decode
    return codecs.utf_8_decode(input, errors, True)
UnicodeDecodeError: 'utf8' codec can't decode byte 0x81 in position 0: invalid start byte
```

## this PR + Line width `40`

We can run the smach_viewer with no error and get line break for long node name.

![Screenshot 2022-07-13 19:02:18](https://user-images.githubusercontent.com/9300063/178708340-d9d601a8-3626-476f-a01e-a444125df220.png)

## Current `melodic-devel` branch + Line width `100`

We can only show multibyte language in one line. So we put long node name, the node can be really long.
We can avoid the error above, but the figure is not beautiful and hard to read when we have a lot of states.
If we put low label width like `40` to show multibyte language in several lines, we get the error above.

![Screenshot 2022-07-22 20:03:28](https://user-images.githubusercontent.com/9300063/180426597-9ace5376-cf2e-4a45-a580-57b2c8edc265.png)

## How to reproduce the error.

you can reproduce the error with this code.

```lisp
(require :state-machine "package://roseus_smach/src/state-machine.l")
(require :state-machine-utils "package://roseus_smach/src/state-machine-utils.l")
(require :state-machine-ros "package://roseus_smach/src/state-machine-ros.l")


(defun make-state-machine ()
  (let ((sm (instance state-machine :init))
        (greet-node-name "「いらっしゃいませ，こんにちは，私はPR2です」")
        (goodbye-node-name "「さようなら，また逢う日まで」"))
    (send sm :add-node (instance state :init greet-node-name
                                 `(lambda-closure nil 0 0 (userdata) :success)))
     (send sm :add-node (instance state :init goodbye-node-name
                                 `(lambda-closure nil 0 0 (userdata) :success)))
   ;; start-state and goal-state
    (send sm :start-state greet-node-name)
    (send sm :goal-state (list :success))
    ;; normal
    (send sm :add-transition greet-node-name goodbye-node-name :success)
    (send sm :add-transition goodbye-node-name :success :success)
    sm))


(ros::roseus "sample")
(setq *sm* (make-state-machine))
(exec-state-machine  *sm*)
```

```bash
rosrun smach_viewer smach_viewer.py
```

cc. @k-okada 