### PR TITLE
Fixed version of incomplete 1st noetic reslease (4.0.0)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ install:
   # check python2 compatibility
   - if [ "${CHECK_PYTHON2_COMPILE}" == "true" ]; then python2 -m compileall .; exit $?; fi
   # check python3 compatibility
-  - if [ "${CHECK_PYTHON3_COMPILE}" == "true" ]; then bash -c "ret=0; trap 'ret=1' ERR; python3 -m compileall .; 2to3 -w -f except -f execfile -f has_key -f import -f raw_input -f zip .; git diff --exit-code . > /dev/null; echo Exitting with \$ret; exit \$ret"; exit $?; fi
+  - if [ "${CHECK_PYTHON3_COMPILE}" == "true" ]; then bash -c "ret=0; trap 'ret=1' ERR; python3 -m compileall .; 2to3 -w -f except -f execfile -f has_key -f raw_input -f zip .; git diff --exit-code . > /dev/null; echo Exitting with \$ret; exit \$ret"; exit $?; fi
   # either install the latest released version of ros_buildfarm
   - pip install pyyaml==5.4.1 ## latest pyyaml raises TypeError: load() missing 1 required positional argument: 'Loader'
   - pip install ros_buildfarm

--- a/smach_viewer/CMakeLists.txt
+++ b/smach_viewer/CMakeLists.txt
@@ -11,5 +11,5 @@ catkin_package(
   )
 
 # Install targets
-install(PROGRAMS scripts/smach_viewer.py
+catkin_install_python(PROGRAMS scripts/smach_viewer.py
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})

--- a/smach_viewer/package.xml
+++ b/smach_viewer/package.xml
@@ -25,6 +25,7 @@
   <build_depend>rostest</build_depend>
 
   <!-- Dependencies needed after this package is compiled. -->
+  <exec_depend>cv_bridge</exec_depend>
   <exec_depend>smach_ros</exec_depend>
   <exec_depend>smach_msgs</exec_depend>
 

--- a/smach_viewer/package.xml
+++ b/smach_viewer/package.xml
@@ -1,4 +1,4 @@
-<package>
+<package format="3">
   <name>smach_viewer</name>
   <version>4.0.0</version>
   <description>
@@ -25,14 +25,23 @@
   <build_depend>rostest</build_depend>
 
   <!-- Dependencies needed after this package is compiled. -->
-  <run_depend>smach_ros</run_depend>
-  <run_depend>smach_msgs</run_depend>
-  <!-- originally depends on xdot : https://github.com/jbohren/xdot/blob/2.0.1/package.xml#L25-L26 -->
-  <run_depend>wxpython</run_depend>
-  <run_depend>graphviz</run_depend>
-  <run_depend>python-gi</run_depend>
-  <run_depend>python-gi-cairo</run_depend>
-  <run_depend>gtk3</run_depend>
+  <exec_depend>smach_ros</exec_depend>
+  <exec_depend>smach_msgs</exec_depend>
+
+  <exec_depend condition="$ROS_PYTHON_VERSION == 2">wxpython</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-xdot</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-xdot</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-wxgtk4.0</exec_depend>
+  <exec_depend>graphviz</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-gi</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-gi</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-rospkg</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-rospkg</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-qt5-bindings</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-qt5-bindings</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-gi-cairo</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-gi-cairo</exec_depend>
+  <exec_depend>gtk3</exec_depend>
 
   <export>
 

--- a/smach_viewer/scripts/smach_viewer.py
+++ b/smach_viewer/scripts/smach_viewer.py
@@ -704,9 +704,9 @@ class SmachViewerFrame(wx.Frame):
         toolbar.AddControl(toggle_auto_focus)
 
         toolbar.AddControl(wx.StaticText(toolbar,-1,"    "))
-        toolbar.AddLabelTool(wx.ID_HELP, 'Help',
+        toolbar.AddTool(wx.ID_HELP, 'Help',
                 wx.ArtProvider.GetBitmap(wx.ART_HELP,wx.ART_OTHER,(16,16)) )
-        toolbar.AddLabelTool(wx.ID_SAVE, 'Save',
+        toolbar.AddTool(wx.ID_SAVE, 'Save',
                 wx.ArtProvider.GetBitmap(wx.ART_FILE_SAVE,wx.ART_OTHER,(16,16)) )
         toolbar.Realize()
 

--- a/smach_viewer/scripts/smach_viewer.py
+++ b/smach_viewer/scripts/smach_viewer.py
@@ -53,6 +53,8 @@ import cv_bridge
 import numpy as np
 import base64
 
+from distutils.version import LooseVersion
+
 try:
     import wxversion
     if wxversion.checkInstalled("2.8"):
@@ -704,10 +706,16 @@ class SmachViewerFrame(wx.Frame):
         toolbar.AddControl(toggle_auto_focus)
 
         toolbar.AddControl(wx.StaticText(toolbar,-1,"    "))
-        toolbar.AddTool(wx.ID_HELP, 'Help',
-                wx.ArtProvider.GetBitmap(wx.ART_HELP,wx.ART_OTHER,(16,16)) )
-        toolbar.AddTool(wx.ID_SAVE, 'Save',
-                wx.ArtProvider.GetBitmap(wx.ART_FILE_SAVE,wx.ART_OTHER,(16,16)) )
+        if LooseVersion(wx.__version__) >= LooseVersion('4.0'):
+            toolbar.AddTool(wx.ID_HELP, 'Help',
+                            wx.ArtProvider.GetBitmap(wx.ART_HELP,wx.ART_OTHER,(16,16)) )
+            toolbar.AddTool(wx.ID_SAVE, 'Save',
+                            wx.ArtProvider.GetBitmap(wx.ART_FILE_SAVE,wx.ART_OTHER,(16,16)) )
+        else:
+            toolbar.AddLabelTool(wx.ID_HELP, 'Help',
+                                 wx.ArtProvider.GetBitmap(wx.ART_HELP,wx.ART_OTHER,(16,16)) )
+            toolbar.AddLabelTool(wx.ID_SAVE, 'Save',
+                                 wx.ArtProvider.GetBitmap(wx.ART_FILE_SAVE,wx.ART_OTHER,(16,16)) )
         toolbar.Realize()
 
         self.Bind(wx.EVT_TOOL, self.ShowControlsDialog, id=wx.ID_HELP)
@@ -1199,11 +1207,17 @@ class SmachViewerFrame(wx.Frame):
         context = wx.ClientDC(self)
         memory = wx.MemoryDC()
         x, y = self.ClientSize
-        bitmap = wx.Bitmap(x, y, -1)
+        if LooseVersion(wx.__version__) >= LooseVersion('4.0'):
+            bitmap = wx.Bitmap(x, y, -1)
+        else:
+            bitmap = wx.EmptyBitmap(x, y, -1)
         memory.SelectObject(bitmap)
         memory.Blit(0, 0, x, y, context, 0, 0)
         memory.SelectObject(wx.NullBitmap)
-        buf = bitmap.ConvertToImage().GetDataBuffer()
+        if LooseVersion(wx.__version__) >= LooseVersion('4.0'):
+            buf = bitmap.ConvertToImage().GetDataBuffer()
+        else:
+            buf = wx.ImageFromBitmap(bitmap).GetDataBuffer()
         img = np.frombuffer(buf, dtype=np.uint8)
         bridge = cv_bridge.CvBridge()
         img_msg = bridge.cv2_to_imgmsg(img.reshape((y, x, 3)), encoding='rgb8')

--- a/smach_viewer/scripts/smach_viewer.py
+++ b/smach_viewer/scripts/smach_viewer.py
@@ -1195,9 +1195,6 @@ class SmachViewerFrame(wx.Frame):
         if self._pub.get_num_connections() < 1:
             rospy.logwarn_once("Publishing {} requries at least one subscribers".format(self._pub.name))
             return
-        if sys.version_info[0] >= 3:
-            rospy.logwarn_once("Publishing {} is not supported on Python3".format(self._pub.name))
-            return
         # image
         context = wx.ClientDC(self)
         memory = wx.MemoryDC()

--- a/smach_viewer/scripts/smach_viewer.py
+++ b/smach_viewer/scripts/smach_viewer.py
@@ -1190,6 +1190,12 @@ class SmachViewerFrame(wx.Frame):
             #    self.set_server(self._servers[0])
 
     def OnTimer(self, event):
+        if self._pub.get_num_connections() < 1:
+            rospy.logwarn_once("Publishing {} requries at least one subscribers".format(self._pub.name))
+            return
+        if sys.version_info[0] >= 3:
+            rospy.logwarn_once("Publishing {} is not supported on Python3".format(self._pub.name))
+            return
         # image
         context = wx.ClientDC(self)
         memory = wx.MemoryDC()

--- a/smach_viewer/scripts/smach_viewer.py
+++ b/smach_viewer/scripts/smach_viewer.py
@@ -92,7 +92,7 @@ except:
     os.chdir(cur_dir)
     # Remove this dir from path
     sys.path = [a for a in sys.path if a not in [this_dir, this_dir_cwd]]
-    # Ignore path ends in smach_viewer/lib/smach_viewer
+    # Ignore path ending with smach_viewer/lib/smach_viewer
     sys.path = [a for a in sys.path if not a.endswith('smach_viewer/lib/smach_viewer')]
     #
     from smach_viewer.xdot import wxxdot
@@ -1193,7 +1193,7 @@ class SmachViewerFrame(wx.Frame):
 
     def OnTimer(self, event):
         if self._pub.get_num_connections() < 1:
-            rospy.logwarn_once("Publishing {} requries at least one subscribers".format(self._pub.name))
+            rospy.logwarn_once("Publishing {} requires at least one subscriber".format(self._pub.name))
             return
         # image
         context = wx.ClientDC(self)

--- a/smach_viewer/scripts/smach_viewer.py
+++ b/smach_viewer/scripts/smach_viewer.py
@@ -92,6 +92,8 @@ except:
     os.chdir(cur_dir)
     # Remove this dir from path
     sys.path = [a for a in sys.path if a not in [this_dir, this_dir_cwd]]
+    # Ignore path ends in smach_viewer/lib/smach_viewer
+    sys.path = [a for a in sys.path if not a.endswith('smach_viewer/lib/smach_viewer')]
     #
     from smach_viewer.xdot import wxxdot
     from xdot.ui.elements import *

--- a/smach_viewer/scripts/smach_viewer.py
+++ b/smach_viewer/scripts/smach_viewer.py
@@ -1199,11 +1199,11 @@ class SmachViewerFrame(wx.Frame):
         context = wx.ClientDC(self)
         memory = wx.MemoryDC()
         x, y = self.ClientSize
-        bitmap = wx.EmptyBitmap(x, y, -1)
+        bitmap = wx.Bitmap(x, y, -1)
         memory.SelectObject(bitmap)
         memory.Blit(0, 0, x, y, context, 0, 0)
         memory.SelectObject(wx.NullBitmap)
-        buf = wx.ImageFromBitmap(bitmap).GetDataBuffer()
+        buf = bitmap.ConvertToImage().GetDataBuffer()
         img = np.frombuffer(buf, dtype=np.uint8)
         bridge = cv_bridge.CvBridge()
         img_msg = bridge.cv2_to_imgmsg(img.reshape((y, x, 3)), encoding='rgb8')

--- a/smach_viewer/src/smach_viewer/xdot/wxxdot.py
+++ b/smach_viewer/src/smach_viewer/xdot/wxxdot.py
@@ -310,7 +310,7 @@ class WxDotWindow(wx.Panel):
 
   ### Cursor manipulation
   def set_cursor(self, cursor_type):
-    self.cursor = wx.StockCursor(cursor_type)
+    self.cursor = wx.Cursor(cursor_type)
     self.SetCursor(self.cursor)
 
   ### Zooming methods

--- a/smach_viewer/src/smach_viewer/xdot/wxxdot.py
+++ b/smach_viewer/src/smach_viewer/xdot/wxxdot.py
@@ -20,7 +20,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 try:
-    # intentionally uses from xdot, instead of from .xdot, because we want to use local xdot for Pytohn2 and sytem xdot for Python3
+    # intentionally use from xdot, instead of from .xdot, because we want to use local xdot for Python2 and system xdot for Python3
     from xdot.ui.elements import *
     from xdot.ui.animation import *
     from xdot.dot.lexer import *

--- a/smach_viewer/src/smach_viewer/xdot/wxxdot.py
+++ b/smach_viewer/src/smach_viewer/xdot/wxxdot.py
@@ -20,13 +20,13 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 try:
-    from .xdot.ui.elements import *
-    from .xdot.ui.animation import *
-    from .xdot.dot.lexer import *
-    from .xdot.dot.parser import *
+    from xdot.ui.elements import *
+    from xdot.ui.animation import *
+    from xdot.dot.lexer import *
+    from xdot.dot.parser import *
     import subprocess
 except:
-    from .xdot import *
+    from xdot import *
 
 # Python 3 renamed the unicode type to str, the old str type has been replaced by bytes.
 if sys.version_info[0] >= 3:

--- a/smach_viewer/src/smach_viewer/xdot/wxxdot.py
+++ b/smach_viewer/src/smach_viewer/xdot/wxxdot.py
@@ -20,6 +20,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 try:
+    # intentionally uses from xdot, instead of from .xdot, because we want to use local xdot for Pytohn2 and sytem xdot for Python3
     from xdot.ui.elements import *
     from xdot.ui.animation import *
     from xdot.dot.lexer import *

--- a/smach_viewer/src/smach_viewer/xdot/wxxdot.py
+++ b/smach_viewer/src/smach_viewer/xdot/wxxdot.py
@@ -29,6 +29,8 @@ try:
 except:
     from xdot import *
 
+from distutils.version import LooseVersion
+
 # Python 3 renamed the unicode type to str, the old str type has been replaced by bytes.
 if sys.version_info[0] >= 3:
     unicode = str
@@ -310,7 +312,10 @@ class WxDotWindow(wx.Panel):
 
   ### Cursor manipulation
   def set_cursor(self, cursor_type):
-    self.cursor = wx.Cursor(cursor_type)
+    if LooseVersion(wx.__version__) >= LooseVersion('4.0'):
+        self.cursor = wx.Cursor(cursor_type)
+    else:
+        self.cursor = wx.StockCursor(cursor_type)
     self.SetCursor(self.cursor)
 
   ### Zooming methods


### PR DESCRIPTION
- use `catkin_install_python` to uses `/usr/bin/env python3` shebang for Noetic
- revert `2to3 -w -f improt`, which beraks on noetic
- #37 does not work on noetic?