### PR TITLE
update use of deprecated functions

### DIFF
--- a/smach_viewer/package.xml
+++ b/smach_viewer/package.xml
@@ -25,6 +25,7 @@
   <build_depend>rostest</build_depend>
 
   <!-- Dependencies needed after this package is compiled. -->
+  <exec_depend>cv_bridge</exec_depend>
   <exec_depend>smach_ros</exec_depend>
   <exec_depend>smach_msgs</exec_depend>
 

--- a/smach_viewer/scripts/smach_viewer.py
+++ b/smach_viewer/scripts/smach_viewer.py
@@ -704,9 +704,9 @@ class SmachViewerFrame(wx.Frame):
         toolbar.AddControl(toggle_auto_focus)
 
         toolbar.AddControl(wx.StaticText(toolbar,-1,"    "))
-        toolbar.AddLabelTool(wx.ID_HELP, 'Help',
+        toolbar.AddTool(wx.ID_HELP, 'Help',
                 wx.ArtProvider.GetBitmap(wx.ART_HELP,wx.ART_OTHER,(16,16)) )
-        toolbar.AddLabelTool(wx.ID_SAVE, 'Save',
+        toolbar.AddTool(wx.ID_SAVE, 'Save',
                 wx.ArtProvider.GetBitmap(wx.ART_FILE_SAVE,wx.ART_OTHER,(16,16)) )
         toolbar.Realize()
 

--- a/smach_viewer/scripts/smach_viewer.py
+++ b/smach_viewer/scripts/smach_viewer.py
@@ -1195,9 +1195,6 @@ class SmachViewerFrame(wx.Frame):
         if self._pub.get_num_connections() < 1:
             rospy.logwarn_once("Publishing {} requries at least one subscribers".format(self._pub.name))
             return
-        if sys.version_info[0] >= 3:
-            rospy.logwarn_once("Publishing {} is not supported on Python3".format(self._pub.name))
-            return
         # image
         context = wx.ClientDC(self)
         memory = wx.MemoryDC()

--- a/smach_viewer/scripts/smach_viewer.py
+++ b/smach_viewer/scripts/smach_viewer.py
@@ -92,7 +92,7 @@ except:
     os.chdir(cur_dir)
     # Remove this dir from path
     sys.path = [a for a in sys.path if a not in [this_dir, this_dir_cwd]]
-    # Ignore path ends in smach_viewer/lib/smach_viewer
+    # Ignore path ending with smach_viewer/lib/smach_viewer
     sys.path = [a for a in sys.path if not a.endswith('smach_viewer/lib/smach_viewer')]
     #
     from smach_viewer.xdot import wxxdot
@@ -1193,7 +1193,7 @@ class SmachViewerFrame(wx.Frame):
 
     def OnTimer(self, event):
         if self._pub.get_num_connections() < 1:
-            rospy.logwarn_once("Publishing {} requries at least one subscribers".format(self._pub.name))
+            rospy.logwarn_once("Publishing {} requires at least one subscriber".format(self._pub.name))
             return
         # image
         context = wx.ClientDC(self)

--- a/smach_viewer/scripts/smach_viewer.py
+++ b/smach_viewer/scripts/smach_viewer.py
@@ -1199,11 +1199,11 @@ class SmachViewerFrame(wx.Frame):
         context = wx.ClientDC(self)
         memory = wx.MemoryDC()
         x, y = self.ClientSize
-        bitmap = wx.EmptyBitmap(x, y, -1)
+        bitmap = wx.Bitmap(x, y, -1)
         memory.SelectObject(bitmap)
         memory.Blit(0, 0, x, y, context, 0, 0)
         memory.SelectObject(wx.NullBitmap)
-        buf = wx.ImageFromBitmap(bitmap).GetDataBuffer()
+        buf = bitmap.ConvertToImage().GetDataBuffer()
         img = np.frombuffer(buf, dtype=np.uint8)
         bridge = cv_bridge.CvBridge()
         img_msg = bridge.cv2_to_imgmsg(img.reshape((y, x, 3)), encoding='rgb8')

--- a/smach_viewer/src/smach_viewer/xdot/wxxdot.py
+++ b/smach_viewer/src/smach_viewer/xdot/wxxdot.py
@@ -310,7 +310,7 @@ class WxDotWindow(wx.Panel):
 
   ### Cursor manipulation
   def set_cursor(self, cursor_type):
-    self.cursor = wx.StockCursor(cursor_type)
+    self.cursor = wx.Cursor(cursor_type)
     self.SetCursor(self.cursor)
 
   ### Zooming methods

--- a/smach_viewer/src/smach_viewer/xdot/wxxdot.py
+++ b/smach_viewer/src/smach_viewer/xdot/wxxdot.py
@@ -20,7 +20,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 try:
-    # intentionally uses from xdot, instead of from .xdot, because we want to use local xdot for Pytohn2 and sytem xdot for Python3
+    # intentionally use from xdot, instead of from .xdot, because we want to use local xdot for Python2 and system xdot for Python3
     from xdot.ui.elements import *
     from xdot.ui.animation import *
     from xdot.dot.lexer import *


### PR DESCRIPTION
To go with #43.

- Update deprecated function use
- Add missing dependencies to package.xml
- Enable image publication for Python3 as well
- Fix typos