### PR TITLE
bump cmake minimum version to avoid warnings on focal

### DIFF
--- a/executive_smach_visualization/CMakeLists.txt
+++ b/executive_smach_visualization/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(executive_smach_visualization)
 find_package(catkin REQUIRED)
 catkin_metapackage()

--- a/smach_viewer/CMakeLists.txt
+++ b/smach_viewer/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 
 project(smach_viewer)
 


### PR DESCRIPTION
Bump CMake version as recommended per http://wiki.ros.org/noetic/Migration#Increase_required_CMake_version_to_avoid_author_warning

Fixes the [warnings on ROS buildfarm](https://build.ros.org/view/Ndev/job/Ndev__executive_smach_visualization__ubuntu_focal_amd64)
