### PR TITLE
[smach_viewer] Fix encoding in executing pickle.loads dependent on python version

### DIFF
--- a/smach_viewer/src/smach_viewer/smach_viewer_base.py
+++ b/smach_viewer/src/smach_viewer/smach_viewer_base.py
@@ -2,7 +2,6 @@
 
 import threading
 
-import base64
 import pickle
 import roslib
 import rospy

--- a/smach_viewer/src/smach_viewer/smach_viewer_base.py
+++ b/smach_viewer/src/smach_viewer/smach_viewer_base.py
@@ -8,6 +8,7 @@ import roslib
 import rospy
 import smach
 import smach_ros
+import sys
 
 from smach_viewer.text_wrapper import TextWrapper
 from smach_viewer.utils import attr_string
@@ -71,8 +72,9 @@ class ContainerNode(object):
 
     def _load_local_data(self, msg):
         """Unpack the user data"""
-        if isinstance(msg.local_data, str):
-            local_data = pickle.loads(msg.local_data.encode('utf-8'))
+        if sys.version_info.major >= 3:
+            local_data = pickle.loads(
+                msg.local_data.encode('utf-8'), encoding='utf-8')
         else:
             local_data = pickle.loads(msg.local_data)
         return local_data


### PR DESCRIPTION
Without this change, the following errors occur when i used `smach_viewer.py`
I fixed it in this PR.
- In python2 (executing smach and smach_viewer in python2)
```
[ERROR] [1681879430.156442] [/smach_viewer]: [bad callback: <bound method SmachViewerFrame._status_msg_update of <__main__.SmachViewerFrame; proxy of <Swig Object of type 'wxFrame *' at 0x561cd640aed0> >>
Traceback (most recent call last):
  File "/opt/ros/melodic/lib/python2.7/dist-packages/rospy/topics.py", line 750, in _invoke_callback
    cb(msg)
  File "/home/tsukamoto/ros/fetch_ws/src/executive_smach_visualization/smach_viewer/scripts/smach_viewer.py", line 530, in _status_msg_update
    SmachViewerBase._status_msg_update(self, msg)
  File "/home/tsukamoto/ros/fetch_ws/src/executive_smach_visualization/smach_viewer/src/smach_viewer/smach_viewer_base.py", line 492, in _status_msg_update
    if container.update_status(msg):
  File "/home/tsukamoto/ros/fetch_ws/src/executive_smach_visualization/smach_viewer/src/smach_viewer/smach_viewer_base.py", line 104, in update_status
    self._local_data._data = self._load_local_data(msg)
  File "/home/tsukamoto/ros/fetch_ws/src/executive_smach_visualization/smach_viewer/src/smach_viewer/smach_viewer_base.py", line 78, in _load_local_data
    msg.local_data.encode('utf-8'), encoding='utf-8')
UnicodeDecodeError: 'ascii' codec can't decode byte 0x88 in position 11: ordinal not in range(128)
]
```

- In python3(executing smach and smach_viewer in python3)
```
[ERROR] [1681878253.415831]: bad callback: <bound method SmachViewerFrame._status_msg_update of <__main__.SmachViewerFrame object at 0x7f8b36b1e1f0>>
Traceback (most recent call last):
  File "/opt/ros/noetic/lib/python3/dist-packages/rospy/topics.py", line 750, in _invoke_callback
    cb(msg)
  File "/home/tsukamoto/ros/fetch_ws/src/ros-visualization/executive_smach_visualization/smach_viewer/scripts/smach_viewer.py", line 530, in _status_msg_update
    SmachViewerBase._status_msg_update(self, msg)
  File "/home/tsukamoto/ros/fetch_ws/src/ros-visualization/executive_smach_visualization/smach_viewer/src/smach_viewer/smach_viewer_base.py", line 489, in _status_msg_update
    if container.update_status(msg):
  File "/home/tsukamoto/ros/fetch_ws/src/ros-visualization/executive_smach_visualization/smach_viewer/src/smach_viewer/smach_viewer_base.py", line 101, in update_status
    self._local_data._data = self._load_local_data(msg)
  File "/home/tsukamoto/ros/fetch_ws/src/ros-visualization/executive_smach_visualization/smach_viewer/src/smach_viewer/smach_viewer_base.py", line 75, in _load_local_data
    local_data = pickle.loads(msg.local_data.encode('utf-8'))
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe5 in position 0: ordinal not in range(128)

```

PS: I did not test in cross-python version  environment such as executing smach in python2 and executing smach_viewer in python3, and executing smach in python3 and smach_viewer in python2.