### PR TITLE
Fix user data unpacking in noetic

### DIFF
--- a/smach_viewer/src/smach_viewer/smach_viewer_base.py
+++ b/smach_viewer/src/smach_viewer/smach_viewer_base.py
@@ -2,6 +2,7 @@
 
 import threading
 
+import base64
 import pickle
 import roslib
 import rospy
@@ -72,8 +73,7 @@ class ContainerNode(object):
     def _load_local_data(self, msg):
         """Unpack the user data"""
         if sys.version_info.major >= 3:
-            local_data = pickle.loads(
-                msg.local_data.encode('utf-8'), encoding='utf-8')
+            local_data = pickle.loads(base64.b64decode(msg.local_data))
         else:
             local_data = pickle.loads(msg.local_data)
         return local_data


### PR DESCRIPTION
:warning::warning: :warning: :warning: :warning: :warning: :warning: :warning: :warning: :warning: :warning:  :warning: :warning: :warning: :warning: :warning: :warning: :warning: :warning: :warning: :warning: :warning: :warning: :warning: 
**TODO: create noetic-devel branch and change the target for this PR**
**I will keep as draft meanwhile**
:warning: :warning: :warning: :warning: :warning: :warning: :warning: :warning: :warning: :warning: :warning: :warning: :warning: :warning: :warning: :warning: :warning: :warning: :warning: :warning: :warning: :warning: :warning: :warning: 

Without this PR, on noetic, unpacking any user data fails with 
```
[/patrol_2_points_smach_viewer ERROR 1699086106.199530, 6.800000]: bad callback: <bound method SmachViewerFrame._status_msg_update of <__main__.SmachViewerFrame object at 0x7f0440864550>>
Traceback (most recent call last):
  File "/opt/ros/noetic/lib/python3/dist-packages/rospy/topics.py", line 750, in _invoke_callback
    cb(msg)
  File "/home/jorge/catkin_ws/executive/src/executive_smach_visualization/smach_viewer/scripts/smach_viewer.py", line 530, in _status_msg_update
    SmachViewerBase._status_msg_update(self, msg)
  File "/home/jorge/catkin_ws/executive/src/executive_smach_visualization/smach_viewer/src/smach_viewer/smach_viewer_base.py", line 490, in _status_msg_update
    if container.update_status(msg):
  File "/home/jorge/catkin_ws/executive/src/executive_smach_visualization/smach_viewer/src/smach_viewer/smach_viewer_base.py", line 102, in update_status
    self._local_data._data = self._load_local_data(msg)
  File "/home/jorge/catkin_ws/executive/src/executive_smach_visualization/smach_viewer/src/smach_viewer/smach_viewer_base.py", line 75, in _load_local_data
    local_data = pickle.loads(
_pickle.UnpicklingError: pickle data was truncated
```
