### PR TITLE
Fix Truncated Pickle Data Error on Ubuntu 22.04 for ROS-O

### DIFF
--- a/smach_viewer/src/smach_viewer/smach_viewer_base.py
+++ b/smach_viewer/src/smach_viewer/smach_viewer_base.py
@@ -3,6 +3,7 @@
 import threading
 
 import pickle
+import base64
 import roslib
 import rospy
 import smach
@@ -72,8 +73,8 @@ class ContainerNode(object):
     def _load_local_data(self, msg):
         """Unpack the user data"""
         if sys.version_info.major >= 3:
-            local_data = pickle.loads(
-                msg.local_data.encode('utf-8'), encoding='utf-8')
+            local_data_raw_bytes = base64.b64decode(msg.local_data)
+            local_data = pickle.loads(local_data_raw_bytes)
         else:
             local_data = pickle.loads(msg.local_data)
         return local_data


### PR DESCRIPTION
Dear maintainers,

When I use the smach_viewer on Ubuntu 22.04 and ROS-O, I met this error:

`  File "/opt/ros/one/lib/python3/dist-packages/smach_viewer/smach_viewer_base.py", line 75, in _load_local_data
    local_data = pickle.loads(
_pickle.UnpicklingError: pickle data was truncated`

So I did some change to make it work.

The change has been tested on Ubuntu 22.04 with ROS-O and Ubuntu 20.04 with ROS Noetic. The tested command is `rosrun smach_viewer smach_viewer.py`

Thank you for the maintenance!