### PR TITLE
fix noetic issue for loading pickle data check if msg.local_data is base64 encoded data

### DIFF
--- a/smach_viewer/src/smach_viewer/smach_viewer_base.py
+++ b/smach_viewer/src/smach_viewer/smach_viewer_base.py
@@ -4,6 +4,7 @@ import threading
 
 import pickle
 import base64
+import re
 import roslib
 import rospy
 import smach
@@ -73,8 +74,12 @@ class ContainerNode(object):
     def _load_local_data(self, msg):
         """Unpack the user data"""
         if sys.version_info.major >= 3:
-            local_data_raw_bytes = base64.b64decode(msg.local_data)
-            local_data = pickle.loads(local_data_raw_bytes)
+            base64_regex = re.compile(r'^[A-Za-z0-9+/]*={0,2}$')
+            if base64_regex.fullmatch(msg.local_data):
+                local_data_raw_bytes = base64.b64decode(msg.local_data)
+                local_data = pickle.loads(local_data_raw_bytes)
+            else:
+                local_data = pickle.loads(msg.local_data.encode('utf-8'))
         else:
             local_data = pickle.loads(msg.local_data)
         return local_data

--- a/smach_viewer/src/smach_viewer/smach_viewer_base.py
+++ b/smach_viewer/src/smach_viewer/smach_viewer_base.py
@@ -73,13 +73,11 @@ class ContainerNode(object):
 
     def _load_local_data(self, msg):
         """Unpack the user data"""
-        if sys.version_info.major >= 3:
-            base64_regex = re.compile(r'^[A-Za-z0-9+/]*={0,2}$')
-            if base64_regex.fullmatch(msg.local_data):
-                local_data_raw_bytes = base64.b64decode(msg.local_data)
-                local_data = pickle.loads(local_data_raw_bytes)
-            else:
-                local_data = pickle.loads(msg.local_data.encode('utf-8'))
+        if re.match(r'^[A-Za-z0-9+/]*={0,2}$', msg.local_data):
+            local_data_raw_bytes = base64.b64decode(msg.local_data)
+            local_data = pickle.loads(local_data_raw_bytes)
+        elif isinstance(msg.local_data, str):
+            local_data = pickle.loads(msg.local_data.encode('utf-8'))
         else:
             local_data = pickle.loads(msg.local_data)
         return local_data

--- a/smach_viewer/src/smach_viewer/smach_viewer_base.py
+++ b/smach_viewer/src/smach_viewer/smach_viewer_base.py
@@ -3,6 +3,7 @@
 import threading
 
 import pickle
+import base64
 import roslib
 import rospy
 import smach
@@ -72,8 +73,8 @@ class ContainerNode(object):
     def _load_local_data(self, msg):
         """Unpack the user data"""
         if sys.version_info.major >= 3:
-            local_data = pickle.loads(
-                msg.local_data.encode('utf-8'), encoding='utf-8')
+            local_data_raw_bytes = base64.b64decode(msg.local_data)
+            local_data = pickle.loads(local_data_raw_bytes)
         else:
             local_data = pickle.loads(msg.local_data)
         return local_data

--- a/smach_viewer/test/test_rosout_error.py
+++ b/smach_viewer/test/test_rosout_error.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+
+import rospy
+import rostest
+import sys
+import unittest
+from rosgraph_msgs.msg import Log
+
+class TestRosoutOutput(unittest.TestCase):
+
+    def setUp(self):
+        rospy.init_node('test_rosout_output', anonymous=True)
+        self.received_error_msg = None
+        rospy.Subscriber('/rosout', Log, self.callback)
+
+    def callback(self, msg):
+        print("received rosout message with level = {}".format(msg.level))
+        if msg.level == Log.ERROR or msg.level == Log.FATAL:
+            self.received_error_msg = msg.msg
+
+    def test_rosout_output(self):
+        rospy.wait_for_message('/rosout', Log, timeout=5)  # Wait for a message
+        wait_time = float(rospy.get_param('~wait_time', 10.))
+        start_time = rospy.Time.now()
+        while not rospy.is_shutdown() and (rospy.Time.now() - start_time).to_sec() < wait_time:
+            rospy.sleep(1.0)
+            self.assertIsNone(self.received_error_msg, "Error message received!") # if not equal, then error
+
+if __name__ == '__main__':
+    rostest.run('smach_viewer', 'test_rosout_output', TestRosoutOutput, sys.argv)

--- a/smach_viewer/test/test_smach.l
+++ b/smach_viewer/test/test_smach.l
@@ -1,0 +1,36 @@
+#!/usr/bin/env roseus
+
+(load "package://roseus_smach/src/state-machine-ros.l")
+(load "package://roseus_smach/src/state-machine-utils.l")
+
+(setq count 0)
+(defun func-foo (&rest args)
+  (format t "Execute state FOO~%")
+  (cond ((< count 3) (incf count) :outcome1)
+	(t :outcome2)))
+(defun func-bar (&rest args)
+  (format t "Execute state BAR~%")
+  :outcome2)
+
+(defun sample-smach ()
+  (let ((sm (instance state-machine :init)))
+    (send sm :add-node (instance state :init :FOO 'func-foo))
+    (send sm :add-node (instance state :init :BAR 'func-bar))
+    ;; goal-states are generated in this method
+    (send sm :goal-state (list :outcome3))
+
+    ;; select a node as start-node
+    (send sm :start-state :FOO)
+    ;; from and to nodes are selected by name or symbol
+    (send sm :add-transition :FOO :BAR :outcome1)
+    (send sm :add-transition :FOO :outcome3 :outcome2)
+    (send sm :add-transition :BAR :FOO :outcome2)
+    sm ))
+
+(defun main ()
+  (ros::roseus "smach_eus")
+  (exec-state-machine (sample-smach))
+  (exit)
+  )
+
+(main)

--- a/smach_viewer/test/test_smach.py
+++ b/smach_viewer/test/test_smach.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+
+import rospy
+import smach
+import smach_ros
+
+class FOO(smach.State):
+    def __init__(self):
+        smach.State.__init__(self, outcomes=['OUTCOME1','OUTCOME2'])
+        self.counter = 0
+
+    def execute(self, userdata):
+        rospy.loginfo('Executing state FOO')
+        if self.counter < 3:
+            self.counter += 1
+            return 'OUTCOME1'
+        else:
+            return 'OUTCOME2'
+
+class BAR(smach.State):
+    def __init__(self):
+        smach.State.__init__(self, outcomes=['OUTCOME2'])
+
+    def execute(self, userdata):
+        rospy.loginfo('Executing state BAR')
+        return 'OUTCOME2'
+
+def main():
+    rospy.init_node('smach_sample2')
+
+    sm_top = smach.StateMachine(outcomes=['OUTCOME3'])
+
+    with sm_top:
+        smach.StateMachine.add('FOO', FOO(), transitions={'OUTCOME1':'BAR', 'OUTCOME2':'OUTCOME3'})
+        smach.StateMachine.add('BAR', BAR(), transitions={'OUTCOME2':'FOO'})
+
+    sis = smach_ros.IntrospectionServer('server_name', sm_top, '/SM_ROOT')
+    sis.start()
+    outcome = sm_top.execute()
+    rospy.spin()
+    sis.stop()
+
+if __name__ == '__main__':
+    main()
+

--- a/smach_viewer/test/test_smach_eus.test
+++ b/smach_viewer/test/test_smach_eus.test
@@ -1,0 +1,9 @@
+<launch>
+  <node pkg="smach_viewer"
+	name="smach_viewer" type="smach_viewer.py"
+	output="screen" />
+  <node	pkg="roseus"
+	name="test_smach_eus" type="roseus" args="$(find smach_viewer)/test/test_smach.l" />
+  <test test-name="smach_viewer_test"
+	pkg="smach_viewer" type="test_rosout_error.py" name="smach_viewer_test" />
+</launch>

--- a/smach_viewer/test/test_smach_py.test
+++ b/smach_viewer/test/test_smach_py.test
@@ -1,0 +1,9 @@
+<launch>
+  <node pkg="smach_viewer"
+	name="smach_viewer" type="smach_viewer.py"
+	output="screen" />
+  <node	pkg="smach_viewer"
+	name="test_smach_py" type="test_smach.py" />
+  <test test-name="smach_viewer_test"
+	pkg="smach_viewer" type="test_rosout_error.py" name="smach_viewer_test" />
+</launch>


### PR DESCRIPTION
fix noetic issue for loading pickle data check if msg.local_data is base64 encoded data, see  https://github.com/ros-visualization/executive_smach_visualization/issues/59

[bug]: fix the bug "_pickle.UnpicklingError: pickle data was truncated"  when used in ubuntu 22.04 and ROS-O