### PR TITLE
forget to remove rostest from find_package(catkin REQUIRED COMPONENTS)

### DIFF
--- a/smach_viewer/CMakeLists.txt
+++ b/smach_viewer/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.3)
 
 project(smach_viewer)
 
-find_package(catkin REQUIRED COMPONENTS rostest)
+find_package(catkin REQUIRED COMPONENTS)
 
 catkin_python_setup()
 


### PR DESCRIPTION
fiexes

```
2025-02-14T05:57:09.7822771Z -- BUILD_SHARED_LIBS is on
2025-02-14T05:57:09.8785089Z -- Could NOT find rostest (missing: rostest_DIR)
2025-02-14T05:57:09.8786659Z -- Could not find the required component 'rostest'. The following CMake error indicates that you either need to install the package with the same name or change your environment so that it can be found.
2025-02-14T05:57:09.8802689Z CMake Error at /usr/share/catkin/cmake/catkinConfig.cmake:82 (find_package):
2025-02-14T05:57:09.8803508Z   Could not find a package configuration file provided by "rostest" with any
2025-02-14T05:57:09.8804116Z   of the following names:
2025-02-14T05:57:09.8804354Z 
2025-02-14T05:57:09.8804495Z     rostestConfig.cmake
2025-02-14T05:57:09.8804864Z     rostest-config.cmake
2025-02-14T05:57:09.8805075Z 
2025-02-14T05:57:09.8805365Z   Add the installation prefix of "rostest" to CMAKE_PREFIX_PATH or set
2025-02-14T05:57:09.8806266Z   "rostest_DIR" to a directory containing one of the above files.  If
2025-02-14T05:57:09.8807006Z   "rostest" provides a separate development package or SDK, be sure it has
2025-02-14T05:57:09.8807625Z   been installed.
2025-02-14T05:57:09.8807937Z Call Stack (most recent call first):
2025-02-14T05:57:09.8808335Z   CMakeLists.txt:5 (find_package)
2025-02-14T05:57:09.8808589Z 
2025-02-14T05:57:09.8808595Z 
2025-02-14T05:57:09.8808780Z -- Configuring incomplete, errors occurred!
2025-02-14T05:57:09.8853298Z 	cd .obj-x86_64-linux-gnu && tail -v -n \+0 CMakeCache.txt
2025-02-14T05:57:09.8867057Z ==> CMakeCache.txt <==
```