### PR TITLE
Bump cmake_minimum_required to avoid deprecation

### DIFF
--- a/executive_smach_visualization/CMakeLists.txt
+++ b/executive_smach_visualization/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(executive_smach_visualization)
 find_package(catkin REQUIRED)
 catkin_metapackage()

--- a/smach_viewer/CMakeLists.txt
+++ b/smach_viewer/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 
 project(smach_viewer)
 


### PR DESCRIPTION
Noetic will be EOL very soon and it was already discussed what last changes would be worthwhile.
This was done in [Discourse](https://discourse.ros.org/t/ros-noetic-end-of-life-may-31-2025/43160/4) .
One point was the cmake_minimum_required version because <3.5 is deprecated in newer CMake version.