### PR TITLE
[smach_viewer] Fix import issue in noble

### DIFF
--- a/smach_viewer/src/smach_viewer/xdot/wxxdot.py
+++ b/smach_viewer/src/smach_viewer/xdot/wxxdot.py
@@ -19,12 +19,14 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import sys
+
 try:
     # intentionally use from xdot, instead of from .xdot, because we want to use local xdot for Python2 and system xdot for Python3
     from xdot.ui.elements import *
     from xdot.ui.animation import *
     from xdot.dot.lexer import *
-    from xdot.dot.parser import *
+    from xdot.dot.parser import XDotParser
     import subprocess
 except:
     from xdot import *


### PR DESCRIPTION
- Fix missing importing `sys`

- Fix the bug in noble
```
    Traceback (most recent call last):
      File "/home/obinata/ros/catkin_ws/devel/lib/smach_viewer/smach_viewer.py", line 15, in <module>
        exec(compile(fh.read(), python_script, 'exec'), context)
      File "/home/obinata/ros/catkin_ws/src/ros-visualization/executive_smach_visualization/smach_viewer/scripts/smach_viewer.py", line 89, in <module>
        from smach_viewer.xdot import wxxdot
      File "/home/obinata/ros/catkin_ws/src/ros-visualization/executive_smach_visualization/smach_viewer/src/smach_viewer/xdot/__init__.py", line 1, in <module>
        from . import wxxdot
      File "/home/obinata/ros/catkin_ws/src/ros-visualization/executive_smach_visualization/smach_viewer/src/smach_viewer/xdot/wxxdot.py", line 30, in <module>
        from xdot.dot.parser import *
      File "<frozen importlib._bootstrap>", line 1410, in _handle_fromlist
      File "<frozen importlib._bootstrap>", line 1400, in _handle_fromlist
    TypeError: 'AttributeError' object is not iterable
```

It seems something happening in `from xdot.dot.parser import *` . In the code, only `XDotParser` is used so I fixed for only importing it.